### PR TITLE
Agregar mensaje final al contar.sh

### DIFF
--- a/contar.sh
+++ b/contar.sh
@@ -5,3 +5,5 @@ do
   lineas=$(wc -l < "loremipsum-$i.txt")
   echo "loremipsum-$i.txt tiene $lineas líneas."
 done
+echo "Conteo finalizado."
+


### PR DESCRIPTION
Este PR agrega el script contar.sh que cuenta las líneas de los archivos loremipsum-*.txt y muestra un mensaje final indicando que el conteo terminó.